### PR TITLE
fix: support null/undefined value

### DIFF
--- a/walk-object.js
+++ b/walk-object.js
@@ -6,6 +6,10 @@ const isObject = require('is-pure-object')
 */
 module.exports = function walkObject(root, fn) {
   function walk(obj, location = []) {
+    if (obj == null) {
+      // skip null and undefined
+      return
+    }
     Object.keys(obj).forEach((key) => {
 
       // Value is an array, call walk on each item in the array


### PR DESCRIPTION
calling `Object.keys` on `null` and `undefined` values will throw an error